### PR TITLE
Optimize makefile

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,30 +1,76 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
 
 jobs:
-  build:
-    name: ${{ matrix.os }} - CI - Go ${{ matrix.go_version }}
+  test:
+    name: ${{ matrix.os }} - Test - Go ${{ matrix.go_version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - 1.15
-          - 1.16
-          - 1.17
+          - "1.20"
         os:
           - ubuntu-latest
     steps:
       - name: Set Up Go ${{ matrix.go_version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
         id: go
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Tests
         id: test
         run: |
           make test
+
+  build:
+    name: Build ${{ matrix.platform }} - Go 1.20
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux_amd64
+          - linux_arm64
+          - darwin_amd64
+          - darwin_arm64
+          - windows_amd64
+    steps:
+      - name: Set Up Go 1.20
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+        id: go
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+      - name: Build ${{ matrix.platform }}
+        id: build
+        run: |
+          make ${{ matrix.platform }}
+      - name: Verify Build Output
+        id: verify
+        run: |
+          echo "Verifying build output for ${{ matrix.platform }}..."
+          ls -la target/
+          BUILD_DIR=$(find target/ -name "chaosblade-*-${{ matrix.platform }}" -type d | head -1)
+          if [ -n "$BUILD_DIR" ] && [ -d "$BUILD_DIR" ]; then
+            echo "✅ Build directory created successfully: $BUILD_DIR"
+            find "$BUILD_DIR" -type f -name "chaos_cloud*" | head -1
+            find "$BUILD_DIR" -type f -name "*.yaml" | head -1
+          else
+            echo "❌ Build directory not found for ${{ matrix.platform }}"
+            exit 1
+          fi
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaosblade-${{ matrix.platform }}
+          path: target/chaosblade-*-${{ matrix.platform }}
+          retention-days: 7

--- a/exec/model/model_linux.go
+++ b/exec/model/model_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 /*
  * Copyright 1999-2020 Alibaba Group Holding Ltd.
  *

--- a/exec/model/model_windows.go
+++ b/exec/model/model_windows.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build windows
+// +build windows
 
 /*
  * Copyright 1999-2020 Alibaba Group Holding Ltd.
@@ -13,7 +13,7 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * See the License for the specific license governing permissions and
  * limitations under the License.
  */
 

--- a/version/version.sh
+++ b/version/version.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Version management script for chaosblade-exec-cloud
+# This script extracts version information from git tags and provides it to the
+# build system
+
+set -e
+
+# Get the latest git tag
+get_latest_tag() {
+    git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0"
+}
+
+# Get the current git commit hash
+get_commit_hash() {
+    git rev-parse --short HEAD 2>/dev/null || echo "unknown"
+}
+
+# Get the build time
+get_build_time() {
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+# Get version from git tag (remove 'v' prefix)
+get_version() {
+    local tag=$(get_latest_tag)
+    echo "${tag#v}"
+}
+
+# Get full version string
+get_full_version() {
+    local version=$(get_version)
+    local commit=$(get_commit_hash)
+    local build_time=$(get_build_time)
+    echo "${version}-${commit}-${build_time}"
+}
+
+# Check if we're on a tagged commit
+is_tagged_commit() {
+    local tag=$(get_latest_tag)
+    local current_commit=$(git rev-parse HEAD)
+    local tag_commit=$(git rev-parse "$tag" 2>/dev/null || echo "")
+    
+    if [ "$current_commit" = "$tag_commit" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Get build type
+get_build_type() {
+    if [ "$(is_tagged_commit)" = "true" ]; then
+        echo "release"
+    else
+        echo "dev"
+    fi
+}
+
+# Main function
+main() {
+    case "${1:-version}" in
+        "version")
+            get_version
+            ;;
+        "full-version")
+            get_full_version
+            ;;
+        "commit")
+            get_commit_hash
+            ;;
+        "build-time")
+            get_build_time
+            ;;
+        "tag")
+            get_latest_tag
+            ;;
+        "build-type")
+            get_build_type
+            ;;
+        "is-tagged")
+            is_tagged_commit
+            ;;
+        *)
+            echo "Usage: $0 {version|full-version|commit|build-time|tag|build-type|is-tagged}"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
`make help`:
```
Available Build Targets:
  build          - Build current platform version
  build_all      - Build all platform versions
  linux_amd64    - Build Linux AMD64 version
  linux_arm64    - Build Linux ARM64 version
  darwin_amd64   - Build macOS AMD64 version
  darwin_arm64   - Build macOS ARM64 version
  windows_amd64  - Build Windows AMD64 version

Other Commands:
  test           - Run tests
  clean          - Clean build products
  all            - Build and test
  help           - Show this help information
  version        - Show version information

Environment Variables:
  BLADE_VERSION  - Specify build version (default: auto-detect from Git Tag)

Usage Examples:
  make help                    # Show help
  make build                   # Build current platform version
  make build_all               # Build all platform versions
  make linux_amd64            # Build Linux AMD64 version
  BLADE_VERSION=1.8.0 make build  # Build with specified version
```